### PR TITLE
Fix mobile navigation and improve responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,9 +106,6 @@
         Trening som tilpasses<span class="dot">.</span><br>
         Fellesskap som vokser<span class="dot">.</span>
       </h2>
-
-     
-      </div>
     </div>
   </section>
 

--- a/kurs.html
+++ b/kurs.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Kalender – My Strongest Side</title>
   <link rel="stylesheet" href="styles.css" />
+  <script src="script.js" defer></script>
   <style>
     /* Lett wrapper-stil for å matche temaet ditt */
     .kalender {
@@ -33,14 +34,17 @@
 <body>
 
   <!-- Navbar (samme som på index) -->
-  <header class="navbar">
+  <header class="navbar" role="navigation" aria-label="Hovedmeny">
     <div class="navbar-left">
-      <a href="index.html"><img src="logo.png" alt="My Strongest Side logo" class="logo" /></a>
+      <a href="index.html" class="logo-link" aria-label="Til forsiden">
+        <img src="logo.png" alt="My Strongest Side logo" class="logo" />
+      </a>
     </div>
 
-    <div class="hamburger" id="hamburger">
+    <button class="hamburger" id="hamburger"
+            aria-label="Åpne meny" aria-expanded="false" aria-controls="nav-menu">
       <span></span><span></span><span></span>
-    </div>
+    </button>
 
     <nav class="navbar-center" id="nav-menu">
       <ul class="nav-links">
@@ -98,13 +102,5 @@
     </noscript>
   </section>
 
-  <!-- Hamburger -->
-  <script>
-    const hamburger = document.getElementById("hamburger");
-    const navMenu = document.getElementById("nav-menu");
-    hamburger.addEventListener("click", () => {
-      navMenu.classList.toggle("active");
-    });
-  </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const hamburger = document.getElementById('hamburger');
+  const navMenu = document.getElementById('nav-menu');
+
+  if (!hamburger || !navMenu) return;
+
+  hamburger.addEventListener('click', () => {
+    const expanded = hamburger.getAttribute('aria-expanded') === 'true';
+    hamburger.setAttribute('aria-expanded', String(!expanded));
+    navMenu.classList.toggle('active');
+  });
+
+  navMenu.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => {
+      navMenu.classList.remove('active');
+      hamburger.setAttribute('aria-expanded', 'false');
+    });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -163,6 +163,12 @@ body {
 }
 .dot { color: #ff6d00; }
 
+@media (max-width: 600px) {
+  .masthead { min-height: 40vh; }
+  .hero-card { padding: 4rem 1.5rem; margin-top: -40px; }
+  .hero-card h1 { font-size: 2rem; }
+}
+
 /* =========================
    MARQUEE (oransje sløyfe)
 ========================= */


### PR DESCRIPTION
## Summary
- Add shared `script.js` to toggle hamburger menu and close after link selection
- Convert course page navbar to accessible button and load shared script
- Adjust hero and masthead styling for smaller screens and clean up markup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34cd1a0848330b846b5d1f7b0940f