### PR TITLE
Refine hero and news grid design

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,10 +98,8 @@
     </div>
   </div>
 <section class="hero">
-  <h1>Mennesker i fokus.<br />Trening som tilpasses.<br />Fellesskap som vokser.</h1>
-</section> 
-    </div>
-  </section>
+  <h1>Mennesker i fokus.<br />Teknologi som forsterker.<br />Resultater som merkes.</h1>
+</section>
 
 <!-- Filter-knapper -->
 <nav class="news-filters">
@@ -113,7 +111,7 @@
 <!-- Nyhetsrutenett -->
 <section class="news-grid">
   <!-- 1 -->
-  <article class="news-item">
+  <article class="news-card">
     <img src="bilde1.jpg" alt="Laptop" />
     <h2 class="news-title">
       Fullbooket et halvt år fremover for Woodnest
@@ -121,25 +119,28 @@
   </article>
 
   <!-- 2: tekstmodul uten bilde -->
-  <article class="news-item text-only">
+  <article class="news-card text-only">
     <a href="#" class="news-link">Norges smarteste bybil</a>
   </article>
 
   <!-- 3 -->
-  <article class="news-item">
+  <article class="news-card">
     <img src="bilde2.jpg" alt="Swipp logo" />
     <h2 class="news-title">Swipp</h2>
   </article>
 
   <!-- 4 -->
-  <article class="news-item">
+  <article class="news-card">
     <img src="bilde3.jpg" alt="Cactus pose" />
     <h2 class="news-title">Cactus</h2>
   </article>
 
   <!-- 5 -->
-  <article class="news-item">
+  <article class="news-card">
     <img src="bilde4.jpg" alt="HH sign" />
     <h2 class="news-title">HH</h2>
   </article>
 </section>
+
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 document.addEventListener('DOMContentLoaded', () => {
-  const items = document.querySelectorAll('.news-item');
+  const items = document.querySelectorAll('.news-card');
   if (!items.length) return;
 
   if ('IntersectionObserver' in window) {

--- a/styles.css
+++ b/styles.css
@@ -327,15 +327,16 @@ body {
 .hero {
   text-align: center;
   padding: 6rem 1rem;
-  background: url('ditt-hero-bilde.jpg') center/cover no-repeat;
-  color: #fff;
+  background: #fff;
 }
 
 .hero h1 {
-  font-size: 2.5rem;
-  font-weight: bold;
-  margin: 0;
-  line-height: 1.3;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 600;
+  line-height: 1.2;
+  max-width: 900px;
+  margin: 0 auto;
+  color: var(--blue-2);
 }
 
 /* Nyhetsliste */
@@ -381,13 +382,6 @@ body {
   text-decoration: none;
   border-radius: 4px;
 }
-/* Grunnstil */
-body {
-  margin: 0;
-  font-family: sans-serif;
-  color: #111;
-}
-
 /* Filter-knapper */
 .news-filters {
   display: flex;
@@ -418,12 +412,17 @@ body {
 }
 
 /* Nyhetskort */
-.news-item {
+.news-card {
   position: relative;
   overflow: hidden;
+  opacity: 0;
+  transition: opacity .5s ease;
+}
+.news-card.visible {
+  opacity: 1;
 }
 
-.news-item img {
+.news-card img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -443,7 +442,7 @@ body {
 }
 
 /* Tekstmodul uten bilde */
-.news-item.text-only {
+.news-card.text-only {
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Update hero section text and styling to highlight core message
- Introduce reusable news card layout for airy grid-based news section
- Adjust intersection observer to target `.news-card` items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b36c7b137883308a583f684b79ebc3