### PR TITLE
style: set hero background to white and heading blue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -326,11 +326,11 @@ body {
   line-height: 1.6;
 }
 
-/* Hero */
+/* Hero - white background with blue heading */
 .hero {
   text-align: center;
   padding: 6rem 1rem;
-  background: var(--blue-2);
+  background: #fff;
 }
 
 .hero h1 {
@@ -339,7 +339,7 @@ body {
   line-height: 1.2;
   max-width: 900px;
   margin: 0 auto;
-  color: #fff;
+  color: var(--blue);
 }
 
 /* Nyhetsliste */


### PR DESCRIPTION
## Summary
- set hero section background to white for better contrast
- use primary blue for hero heading text
- document hero color choices in CSS comment

## Testing
- `npx --yes stylelint styles.css` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68b4233e797883309683c10cb8fd09cc