### PR TITLE
Show news card images immediately

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -418,11 +418,6 @@ body {
 .news-card {
   position: relative;
   overflow: hidden;
-  opacity: 0;
-  transition: opacity .5s ease;
-}
-.news-card.visible {
-  opacity: 1;
 }
 
 .news-card img {


### PR DESCRIPTION
## Summary
- Remove opacity/animation on `.news-card` so images display without waiting for JavaScript

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4284a94e08330ad66355048952f20