### PR TITLE
Fix about page hero image path

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,7 +40,7 @@
   <script src="script.js" defer></script>
 
   <!-- 1) Toppbilde (samme høyde/klasse som forsiden for konsekvent look) -->
-  <section class="masthead masthead--about" style="background-image:url('about-hero.jpg');"></section>
+  <section class="masthead masthead--about" style="background-image:url('hero-large.jpg');"></section>
 
   <!-- 2) Blå hero-boks som overlapper masthead -->
   <section class="hero-card">


### PR DESCRIPTION
## Summary
- Use existing `hero-large.jpg` to ensure About page hero image loads correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb79f94e3483308f736551dc028261