### PR TITLE
Move supporters section outside two-column container

### DIFF
--- a/about.html
+++ b/about.html
@@ -122,29 +122,6 @@
           <a class="btn" href="frivillig.html" target="_blank" rel="noopener">Les mer</a>
         </div>
       </article>
-      <!-- STØTTET AV -->
-<section class="supporters">
-  <div class="container">
-    <h2 class="supporters-title">Støttet av</h2>
-
-    <ul class="supporter-logos" aria-label="Samarbeid og støtte">
-      <li class="supporter">
-        <a href="https://cp.no" target="_blank" rel="noopener noreferrer" class="supporter-link" aria-label="CP-foreningen Vestland (åpnes i ny fane)">
-          <img src="cp.jpg" alt="CP-foreningen Vestland" loading="lazy" class="supporter-img">
-        </a>
-        <p class="supporter-caption">CP-foreningen Vestland</p>
-      </li>
-
-      <li class="supporter">
-        <a href="https://www.hvl.no/om/organisering/fellesadministrasjonen/forsking-innovasjon/hvl-skape/" target="_blank" rel="noopener noreferrer" class="supporter-link" aria-label="HVL Skape (åpnes i ny fane)">
-          <img src="hvl.jpg" alt="HVL Skape" loading="lazy" class="supporter-img">
-        </a>
-        <p class="supporter-caption">Innovasjonsstøtte fra HVL Skape</p>
-      </li>
-    </ul>
-  </div>
-</section>
-
       <!-- Bilde -->
       <aside class="media-right">
         <figure>
@@ -153,6 +130,29 @@
         </figure>
       </aside>
     </div> <!-- /container two-col -->
+
+  <!-- STØTTET AV -->
+  <section class="supporters">
+    <div class="container">
+      <h2 class="supporters-title">Støttet av</h2>
+
+      <ul class="supporter-logos" aria-label="Samarbeid og støtte">
+        <li class="supporter">
+          <a href="https://cp.no" target="_blank" rel="noopener noreferrer" class="supporter-link" aria-label="CP-foreningen Vestland (åpnes i ny fane)">
+            <img src="cp.jpg" alt="CP-foreningen Vestland" loading="lazy" class="supporter-img">
+          </a>
+          <p class="supporter-caption">CP-foreningen Vestland</p>
+        </li>
+
+        <li class="supporter">
+          <a href="https://www.hvl.no/om/organisering/fellesadministrasjonen/forsking-innovasjon/hvl-skape/" target="_blank" rel="noopener noreferrer" class="supporter-link" aria-label="HVL Skape (åpnes i ny fane)">
+            <img src="hvl.jpg" alt="HVL Skape" loading="lazy" class="supporter-img">
+          </a>
+          <p class="supporter-caption">Innovasjonsstøtte fra HVL Skape</p>
+        </li>
+      </ul>
+    </div>
+  </section>
   </section> <!-- /section -->
 
  


### PR DESCRIPTION
## Summary
- restructure about page so supporters section appears after the two-column container
- keep article and aside as the only children inside the two-column layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb47f9fa083308ee0c2773e79d9e7