### PR TITLE
Moderniser kontakt-siden med tydeligere struktur og tilgjengelighet

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -14,7 +14,7 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-LK0WY59R15"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag(){dataLayer.push(arguments);} 
     gtag('js', new Date());
     gtag('config', 'G-LK0WY59R15');
   </script>
@@ -30,6 +30,26 @@
   <script>document.documentElement.classList.add('js');</script>
 
   <style>
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: -100%;
+      z-index: 2000;
+      background: #0f172a;
+      color: #ffffff;
+      padding: 0.75rem 1rem;
+      border-radius: 0.6rem;
+      text-decoration: none;
+      font-weight: 700;
+      transition: top 0.2s ease;
+    }
+
+    .skip-link:focus-visible {
+      top: 1rem;
+      outline: 3px solid #fbbf24;
+      outline-offset: 2px;
+    }
+
     .hp-field {
       position: absolute !important;
       left: -9999px !important;
@@ -44,64 +64,178 @@
       margin: 0 !important;
     }
 
+    .contact-hero h1 {
+      max-width: 18ch;
+      margin-bottom: 1rem;
+    }
+
+    .contact-hero p {
+      max-width: 70ch;
+      color: #334155;
+      font-size: 1.08rem;
+      line-height: 1.7;
+      margin: 0;
+    }
+
+    .contact-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+      gap: clamp(1.25rem, 3vw, 2rem);
+      align-items: start;
+    }
+
+    .contact-panel,
+    .contact-info-card {
+      background: #ffffff;
+      border: 1px solid #dbe2ea;
+      border-radius: 1.15rem;
+      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+    }
+
+    .contact-panel {
+      padding: clamp(1.25rem, 3vw, 2rem);
+    }
+
+    .contact-panel h2 {
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+    }
+
     .contact-help-text {
-      margin: 0 0 1.25rem 0;
-      color: var(--muted, #475569);
+      margin: 0 0 1.35rem 0;
+      color: #334155;
+      line-height: 1.65;
     }
 
     .contact-quick-links {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin: 0 0 1.25rem 0;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+      margin: 0 0 1.5rem 0;
     }
 
     .contact-quick-links button {
-      border: 1px solid rgba(15, 23, 42, 0.12);
-      background: #fff;
-      border-radius: 999px;
-      padding: 10px 14px;
+      border: 1px solid #cbd5e1;
+      background: #f8fafc;
+      border-radius: 0.95rem;
+      padding: 0.95rem 1rem;
+      text-align: left;
       font: inherit;
+      font-weight: 600;
+      color: #0f172a;
+      line-height: 1.4;
       cursor: pointer;
+      min-height: 3.25rem;
+      transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .contact-quick-links button:hover,
-    .contact-quick-links button:focus-visible {
-      border-color: rgba(15, 23, 42, 0.28);
-      outline: none;
+    .contact-quick-links button:hover {
+      border-color: #94a3b8;
+      background: #f1f5f9;
     }
+
+    .contact-sidebar {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .contact-info-card {
+      padding: 1.3rem 1.3rem 1.2rem;
+    }
+
+    .contact-info-card h3 {
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+      font-size: 1.15rem;
+    }
+
+    .contact-info-card p,
+    .contact-info-card li {
+      color: #1e293b;
+      line-height: 1.65;
+    }
+
+    .contact-info-card p {
+      margin: 0 0 0.4rem;
+    }
+
+    .contact-info-card ul {
+      margin: 0;
+      padding-left: 1.15rem;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    :where(a, button, input, textarea):focus-visible {
+      outline: 3px solid #f59e0b;
+      outline-offset: 2px;
+      box-shadow: 0 0 0 2px #ffffff;
+    }
+
+    input::placeholder,
+    textarea::placeholder {
+      color: #64748b;
+      opacity: 1;
+    }
+
+    .form-feedback {
+      margin-top: 1rem;
+      color: #0f172a;
+      font-weight: 600;
+    }
+
+    .form-privacy-note {
+      color: #334155;
+      line-height: 1.6;
+    }
+
+    @media (max-width: 900px) {
+      .contact-layout {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .contact-quick-links {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .site-footer__social-list { display:flex !important; gap:14px !important; align-items:center !important; }
+    .site-footer__social-list .social-link { width:36px !important; height:36px !important; display:inline-flex !important; }
+    .site-footer__social-list .social-link img { width:36px !important; height:36px !important; display:block !important; object-fit:contain !important; }
   </style>
 </head>
 
 <body class="page-kontakt">
+  <a class="skip-link" href="#main-content">Hopp til hovedinnhold</a>
   <header data-component="site-header"></header>
 
-  <main>
-    <section class="section section--light fade-in">
+  <main id="main-content">
+    <section class="section section--light fade-in contact-hero">
       <div class="container fade-in delay-1">
         <p class="eyebrow">Kontakt</p>
-        <h1 class="fade-in delay-2">Ta kontakt med oss</h1>
+        <h1 class="fade-in delay-2">Har du spørsmål om trening, tilrettelegging eller gruppetilbud?</h1>
         <p class="fade-in delay-3">
-          Vi svarer gjerne på spørsmål om gruppetrening, treningstilbud, samarbeid eller hvordan du kan komme i gang.
-          Send oss en melding, så følger vi opp så raskt vi kan.
+          Ta kontakt dersom du ønsker å melde interesse, stille spørsmål eller høre mer om hvordan My Strongest Side kan bidra.
+          Vi svarer gjerne deltakere, pårørende, fagpersoner og samarbeidspartnere.
         </p>
       </div>
     </section>
 
     <section class="section fade-in">
-      <div class="container contact-grid">
-        <article class="contact-card fade-in delay-2">
-          <h2>Ta kontakt om gruppetrening</h2>
+      <div class="container contact-layout">
+        <article class="contact-panel fade-in delay-2">
+          <h2>Send oss en melding</h2>
           <p class="contact-help-text">
-            Har du spørsmål om treningsgruppene våre, eller ønsker du å melde interesse for en av gruppene?
-            Send oss en melding, så tar vi kontakt.
+            Du kan bruke skjemaet for å melde interesse for gruppetrening, spørre om tilrettelegging eller ta kontakt om samarbeid.
           </p>
 
-          <div class="contact-quick-links" aria-label="Hurtigvalg for melding">
-            <button type="button" data-message-template="Jeg ønsker informasjon om ungdomsgruppen (12–15 år).">Ungdomsgruppen</button>
-            <button type="button" data-message-template="Jeg ønsker informasjon om gruppetrening fra 16 år og oppover.">Fra 16 år</button>
-            <button type="button" data-message-template="Jeg ønsker informasjon om trening med tett oppfølging fra 16 år.">Tett oppfølging</button>
-            <button type="button" data-message-template="Jeg ønsker å høre mer om samarbeid med My Strongest Side.">Samarbeid</button>
+          <div class="contact-quick-links" aria-label="Hurtigvalg for meldingstype">
+            <button type="button" data-message-template="Jeg ønsker å melde interesse for ungdomsgruppen.">Meld interesse for ungdomsgruppen</button>
+            <button type="button" data-message-template="Jeg ønsker å melde interesse for gruppetrening fra 16 år.">Meld interesse fra 16 år</button>
+            <button type="button" data-message-template="Jeg har spørsmål om tilrettelegging.">Spør om tilrettelegging</button>
+            <button type="button" data-message-template="Jeg ønsker å ta kontakt om samarbeid.">Ta kontakt om samarbeid</button>
           </div>
 
           <form id="contactForm" name="contact" method="POST" data-netlify="true" netlify-honeypot="company" data-js="contact-form">
@@ -129,12 +263,12 @@
             </div>
 
             <div class="form-group">
-              <label for="message">Melding</label>
-              <textarea id="message" name="message" rows="5" required minlength="10" maxlength="2000" placeholder="Fortell kort hva du lurer på, eller hvilken gruppe du er interessert i."></textarea>
+              <label for="message">Hva ønsker du hjelp med?</label>
+              <textarea id="message" name="message" rows="5" required minlength="10" maxlength="2000" placeholder="Skriv gjerne kort hva det gjelder, så følger vi deg opp videre."></textarea>
             </div>
 
             <button type="submit" class="btn btn--primary">Send melding</button>
-            <div class="form-feedback" hidden data-js="form-feedback"></div>
+            <div class="form-feedback" hidden data-js="form-feedback" aria-live="polite" role="status"></div>
 
             <p class="form-privacy-note">
               Ved innsending lagrer vi kontaktinformasjonen din for å kunne svare på henvendelsen.
@@ -144,11 +278,23 @@
           </form>
         </article>
 
-        <aside class="contact-info fade-in delay-3">
-          <h3>Kontaktinformasjon</h3>
-          <p><strong>My Strongest Side® AS</strong></p>
-          <p><a href="/kontakt.html">Meld interesse eller still spørsmål</a></p>
-          <p>Adresse: Brages veg 3, 5221 Nesttun</p>
+        <aside class="contact-sidebar fade-in delay-3" aria-label="Kontaktinformasjon og henvendelser">
+          <section class="contact-info-card">
+            <h3>Kontaktinformasjon</h3>
+            <p><strong>My Strongest Side® AS</strong></p>
+            <p><a href="/kontakt.html">Send e-post</a></p>
+            <p>Ring oss på <a href="tel:+4741439384">+47 41 43 93 84</a></p>
+            <p>Brages veg 3, 5221 Nesttun</p>
+          </section>
+
+          <section class="contact-info-card">
+            <h3>Dette kan du ta kontakt om</h3>
+            <ul>
+              <li>Gruppetrening for ungdom og voksne</li>
+              <li>Tilrettelegging ved syns- eller bevegelsesutfordringer</li>
+              <li>Samarbeid med fagmiljø, organisasjoner og treningssentre</li>
+            </ul>
+          </section>
         </aside>
       </div>
     </section>
@@ -222,12 +368,6 @@
       });
     });
   </script>
-
-  <style>
-    .site-footer__social-list { display:flex !important; gap:14px !important; align-items:center !important; }
-    .site-footer__social-list .social-link { width:36px !important; height:36px !important; display:inline-flex !important; }
-    .site-footer__social-list .social-link img { width:36px !important; height:36px !important; display:block !important; object-fit:contain !important; }
-  </style>
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 </body>


### PR DESCRIPTION
### Motivation
- Oppdatere kontakt-siden til et mer moderne, profesjonelt og tillitvekkende uttrykk samtidig som funksjonaliteten beholdes. 
- Gjøre siden tydeligere for deltakere, pårørende, fagpersoner og samarbeidspartnere og forbedre universell utforming for synshemmede og tastaturbrukere. 
- Beholde eksisterende Netlify-skjema, Cookiebot og analytics-funksjonalitet uten å endre skjemaets format eller skjema-logikk. 

### Description
- Harmonisert hero-seksjon med ny overskrift `Har du spørsmål om trening, tilrettelegging eller gruppetilbud?` og oppdatert ingress i tråd med målgrupper. 
- Bygget om layout til en moderne responsiv 2-kolonne grid (`.contact-layout`) med skjema i venstre kolonne og handlingsorienterte informasjonskort i høyre kolonne, og fallback til én kolonne på mobil. 
- Erstattet små pill-knapper med større valgkort/knapper i `.contact-quick-links` som beholder `data-message-template`-logikken og eksisterende JS som fyller `#message`. 
- Forbedret tilgjengelighet ved å legge til en skip-link (`Hopp til hovedinnhold`), `main id="main-content"`, tydelig `:focus-visible` for lenker/knapper/inputs/textarea, økt kontrast for hjelpetekst/brødtekst/placeholder og `aria-live` på form-feedback, samt `aria-label` på hurtigvalg-seksjonen. 
- Oppdatert skjema-tekster og struktur med ny skjemaoverskrift `Send oss en melding`, hjelpetekst, og label `Hva ønsker du hjelp med?`, og lagt inn to informasjonsekort med kontaktinfo og temaer for henvendelser. 
- Ryddet og samlet nye stilregler i sidens `style`-blokk for visuell forbedring (luft, typografi, kort-styling med myke hjørner og subtil skygge) uten å fjerne eksisterende funksjoner og script-lastere. 
- Beholdt uendret: `form name="contact"`, `data-netlify="true"`, `netlify-honeypot="company"`, skjult `form-name`-input og eksisterende JS for `data-message-template`. 

### Testing
- Bekreftet at Netlify-attributtene og skjult `form-name` fortsatt finnes ved å søke etter `name="contact"`, `data-netlify="true"`, `netlify-honeypot="company"` og `form-name`, og denne sjekken lykkes. 
- Startet lokal HTTP-server mot arbeidskatalogen og verifiserte at den oppdaterte siden serveres lokalt, og oppstarten lyktes. 
- Genererte et skjermbilde av den oppdaterte siden ved hjelp av Playwright for visuell verifisering, og skjermbildet ble produsert uten feil. 
- Verifisert at hurtigvalgs-knappene fortsatt fyller `#message` ved å kontrollere eksisterende DOM-lyttere og at denne funksjonaliteten fungerte i testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac09d418408330acfea8b480844c9d)