### PR TITLE
Add ™ symbol to Tæpp og tren across site pages

### DIFF
--- a/Seminar.html
+++ b/Seminar.html
@@ -701,17 +701,17 @@
 
           <p class="reveal d4 myss-lead">Høgskulen på Vestlandet, Campus Kronstad, lørdag 28. februar 2026. Lunsj er inkludert.</p>
 
-          <p class="reveal d4 myss-lead">My Strongest Side inviterer til seminar i forbindelse med pilotstart for Tæpp og tren, et treningssystem for apparattrening i ordinære treningsmiljøer. Ved å skanne en QR-kode eller tappe med mobilen får du konkrete instruksjoner og forslag til tilpasninger direkte på apparatet. Målet er at flere skal kunne trene tryggere og mer selvstendig med større forutsigbarhet og mindre behov for tett og personavhengig veiledning.</p>
+          <p class="reveal d4 myss-lead">My Strongest Side inviterer til seminar i forbindelse med pilotstart for Tæpp og tren™, et treningssystem for apparattrening i ordinære treningsmiljøer. Ved å skanne en QR-kode eller tappe med mobilen får du konkrete instruksjoner og forslag til tilpasninger direkte på apparatet. Målet er at flere skal kunne trene tryggere og mer selvstendig med større forutsigbarhet og mindre behov for tett og personavhengig veiledning.</p>
 
           <p class="reveal d4 myss-lead">Seminaret retter seg mot treningsbransjen, fagmiljøer innen rehabilitering og habilitering, fagpersoner, studenter, leverandører, forskere og personer med funksjonsvariasjoner.</p>
 
           <h2 class="reveal d3">Dette får du på seminaret</h2>
 
-          <p>Vi markerer lanseringen og pilotstarten av My Strongest Side® sitt nye treningssystem «Tæpp og tren» for apparattrening.</p>
+          <p>Vi markerer lanseringen og pilotstarten av My Strongest Side® sitt nye treningssystem «Tæpp og tren™» for apparattrening.</p>
 
           <p>På seminaret får du:</p>
           <ul>
-            <li>En introduksjon til «Tæpp og tren», et QR- og NFC-basert treningssystem utviklet for å gjøre apparattrening mer tilgjengelig</li>
+            <li>En introduksjon til «Tæpp og tren™», et QR- og NFC-basert treningssystem utviklet for å gjøre apparattrening mer tilgjengelig</li>
             <li>Innblikk i pilotprosjektet, hvem det er for, hvordan det brukes og hva vi ønsker å lære</li>
             <li>Brukerperspektivet, med erfaringer fra personer som har behov for tilrettelagt trening</li>
             <li>Faglige innlegg fra dyktige foredragsholdere innen trening, helse og tilrettelegging</li>
@@ -727,7 +727,7 @@
               Hos oss får du trygg, faglig forankret trening i små grupper, med individuelt tilpassede øvelser, uavhengig av funksjon, erfaring eller utgangspunkt. I mars går vi inn i vår femte sesong, og vi har hatt i snitt 19 deltakere på gruppetimene.
             </p>
             <p class="reveal d4">
-              Tæpp og tren er My Strongest Side sitt treningssystem på utvalgte, tydelig merkede apparater. Du skanner en QR-kode eller tapper med mobilen og får veiledning, øvelser og forslag til tilpasninger som gjør treningen tryggere og mer forutsigbar. De utvalgte apparatene og merkingen er universelt utformet, slik at løsningen er enkel å kjenne igjen og bruke, også for personer som veksler mellom helsetjeneste og ordinær trening. All data er anonymisert, og du trenger ingen innlogging for å bruke systemet.
+              Tæpp og tren™ er My Strongest Side sitt treningssystem på utvalgte, tydelig merkede apparater. Du skanner en QR-kode eller tapper med mobilen og får veiledning, øvelser og forslag til tilpasninger som gjør treningen tryggere og mer forutsigbar. De utvalgte apparatene og merkingen er universelt utformet, slik at løsningen er enkel å kjenne igjen og bruke, også for personer som veksler mellom helsetjeneste og ordinær trening. All data er anonymisert, og du trenger ingen innlogging for å bruke systemet.
             </p>
             <p class="reveal d4">
               Piloten gjennomføres våren 2026 med Trene Sammen Fantoft som hovedarena, der løsningen testes i ordinær drift for å samle erfaringer og legge grunnlag for videre utrulling. Energisenteret ved Haukeland universitetssjukehus bidrar som fagmiljø og med erfaringer fra rehabilitering og habilitering, slik at løsningen blir lettere å ta i bruk på tvers av arenaer. Treningssentre som tilbyr løsningen er godkjente sentre. Godkjenningen innebærer blant annet universelt utformet merking på utvalgte apparater, tydelig og standardisert skilting, og en lokal struktur for trygg oppfølging og tilrettelegging. Løsningen er faglig forankret, blant annet med utgangspunkt i metodeboken til Norsk kvalitets- og oppfølgingsregister for cerebral parese (NorCP).
@@ -831,7 +831,7 @@
                 <li><strong>Kl. 13:10</strong> «Verdier, likeverd og deltakelse», Einar Steensnæs, tidligere statsråd og direktør, Oslosenteret for fred og menneskerettigheter i Oslo</li>
                 <li><strong>Kl. 13:40</strong> Pause</li>
                 <li><strong>Kl. 13:55</strong> Fra plan til gjennomføring: «Mestring i praksis», Sivert Helland Veseth, fysioterapeut, Energisenteret for barn og unge, Helse Bergen</li>
-                <li><strong>Kl. 14:15</strong> Demonstrasjon av My Strongest Side® Tæpp og tren treningssystem, Alexander Sviggum, ergoterapeut og daglig leder av My Strongest Side AS</li>
+                <li><strong>Kl. 14:15</strong> Demonstrasjon av My Strongest Side® Tæpp og tren™ treningssystem, Alexander Sviggum, ergoterapeut og daglig leder av My Strongest Side AS</li>
                 <li><strong>Kl. 14:30</strong> Innlegg av Mio BPA, innleder annonseres</li>
                 <li><strong>Kl. 14:40</strong> Innlegg av Eli Færevaag Jacobsen, ergoterapeut, Atterås AS</li>
                 <li><strong>Kl. 14:50</strong> Samtale, refleksjon og spørsmål, panel med alle innledere, ledes av Bente Heggø Olsen</li>

--- a/frivillig.html
+++ b/frivillig.html
@@ -329,7 +329,7 @@
         </p>
 
         <p style="margin-top:12px;opacity:.92;max-width:72ch;">
-          <strong>Nytt denne sesongen:</strong> Vi benytter <em>Tæpp og tren</em>, en løsning som gir både deltakere og veiledere kunnskap om hvordan man kan trene personer med funksjonsvariasjoner. Løsningen er utviklet av Alexander Sviggum og har fått innovasjonsmidler fra HVL.
+          <strong>Nytt denne sesongen:</strong> Vi benytter <em>Tæpp og tren™</em>, en løsning som gir både deltakere og veiledere kunnskap om hvordan man kan trene personer med funksjonsvariasjoner. Løsningen er utviklet av Alexander Sviggum og har fått innovasjonsmidler fra HVL.
         </p>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@
               </p>
 
               <p>
-                I mars lanserer vi <strong>Tæpp og tren</strong>, <strong>My Strongest Side</strong>
+                I mars lanserer vi <strong>Tæpp og tren™</strong>, <strong>My Strongest Side</strong>
                 sin nye løsning for enkel veiledning på apparater. Utvalgte treningsapparater er
                 merket, og du tapper bare på apparatet for å få veiledning, øvelser og forslag
                 til tilpasninger som gjør treningen tryggere og mer forutsigbar.

--- a/index_live.html
+++ b/index_live.html
@@ -78,7 +78,7 @@ img, svg, video, iframe { max-width: 100%; height: auto; }
           Hos oss får du trygg, faglig forankret trening i små grupper, med individuelt tilpassede øvelser, uavhengig av funksjon, erfaring eller utgangspunkt.
         </p>
         <p>
-          I mars lanserer vi <strong>Tæpp og tren</strong>, <strong>My Strongest Side®</strong> sin nye løsning for enkel veiledning på apparater.
+          I mars lanserer vi <strong>Tæpp og tren™</strong>, <strong>My Strongest Side®</strong> sin nye løsning for enkel veiledning på apparater.
           Utvalgte treningsapparater er merket, og du tapper bare på apparatet for å få veiledning, øvelser og forslag til tilpasninger som gjør treningen tryggere og mer forutsigbar.
         </p>
         <p>

--- a/main.html
+++ b/main.html
@@ -324,7 +324,7 @@ header[data-component="site-header"]{
             </p>
 
             <p>
-              I mars lanserer vi <strong>Tæpp og tren</strong>, <strong>My Strongest Side</strong> sin nye løsning for enkel veiledning på apparater.
+              I mars lanserer vi <strong>Tæpp og tren™</strong>, <strong>My Strongest Side</strong> sin nye løsning for enkel veiledning på apparater.
               Utvalgte treningsapparater er merket, og du tapper bare på apparatet for å få veiledning, øvelser og forslag til tilpasninger som gjør treningen tryggere og mer forutsigbar.
             </p>
 

--- a/om-oss.html
+++ b/om-oss.html
@@ -175,7 +175,7 @@
           Hos oss får du trygg, faglig forankret trening i små grupper, med individuelt tilpassede øvelser, uavhengig av funksjon, erfaring eller utgangspunkt.
         </p>
         <p class="reveal d3">
-          I mars lanserer vi <strong>Tæpp og tren</strong>, <strong>My Strongest Side®</strong> sin nye løsning for enkel veiledning på apparater.
+          I mars lanserer vi <strong>Tæpp og tren™</strong>, <strong>My Strongest Side®</strong> sin nye løsning for enkel veiledning på apparater.
           Utvalgte treningsapparater er merket, og du tapper bare på apparatet for å få veiledning, øvelser og forslag til tilpasninger som gjør treningen tryggere og mer forutsigbar.
         </p>
         <p class="reveal d3">


### PR DESCRIPTION
### Motivation
- Ensure every site mention of the product name `Tæpp og tren` includes the trademark symbol for consistent branding and legal clarity.

### Description
- Ran a scripted replacement that updates occurrences of `Tæpp og tren` to `Tæpp og tren™` using a Python regex and applied the change to HTML assets. 
- Updated files: `index.html`, `index_live.html`, `main.html`, `om-oss.html`, `frivillig.html`, and `Seminar.html`.
- Committed the changes with message `Add trademark symbol to Tæpp og tren mentions`.

### Testing
- Executed the replacement script (`python3 - <<'PY' ... PY`) which reported `6` files updated and completed successfully. 
- Verified replacements with `rg -n "Tæpp og tren"` across the modified files and confirmed `™` is present in each updated occurrence. 
- Served the site locally with `python3 -m http.server 4173 --bind 0.0.0.0` and captured a verification screenshot via Playwright to validate the rendered text, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac0fb28694833099aa6d3d8adaf23d)