### PR TITLE
Standardize site footer and add required footer scripts to all HTML pages

### DIFF
--- a/Individuelloppfølging.html
+++ b/Individuelloppfølging.html
@@ -234,47 +234,64 @@
 
   <!-- FOOTER -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-            
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- External JS (ONE source) --><script src="menu.js" defer></script>
 
@@ -309,5 +326,13 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/Seminar.html
+++ b/Seminar.html
@@ -985,5 +985,12 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/aktuelt/cp-bladet-myss.html
+++ b/aktuelt/cp-bladet-myss.html
@@ -227,46 +227,64 @@
 
   <!-- FOOTER (samme struktur som du bruker) -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="../components/footer-links.js" defer></script>
   <script src="../menu.js" defer></script>
@@ -296,5 +314,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/cookies.html
+++ b/cookies.html
@@ -80,5 +80,14 @@
       });
     });
   </script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/foresatte.html
+++ b/foresatte.html
@@ -665,5 +665,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/frivillig.html
+++ b/frivillig.html
@@ -399,5 +399,12 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/gruppetrening.html
+++ b/gruppetrening.html
@@ -497,52 +497,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
-
-      <div class="site-footer__top">
-        <div>
-          <h3 class="site-footer__title">Gruppetrening</h3>
-          <div class="site-footer__contact-lines">
-            <div>For deg som ønsker lettere tilpasninger eller tett veiledning</div>
-            <div>Torsdager og fredager</div>
-            <div>Trene Sammen Fantoft og Sotra Sportsenter</div>
-          </div>
-        </div>
-
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>Alexander Sviggum</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
-        </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
-      </div>
-
-      <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
     </div>
-  </footer>
+
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
+
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="menu.js" defer></script>
   <script>
@@ -551,5 +563,14 @@
       if (yearEl) yearEl.textContent = new Date().getFullYear();
     });
   </script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -625,64 +625,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img
-          src="/bilder/myss-logo-footer.png"
-          alt="My Strongest Side"
-          class="site-footer__logo"
-        />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br />5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a
-              class="social-link"
-              href="https://www.facebook.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Facebook"
-            >
-              <img src="/icons/facebook.png" alt="" aria-hidden="true" />
-            </a>
-            <a
-              class="social-link"
-              href="https://www.instagram.com/mystrongestside/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Instagram"
-            >
-              <img src="/icons/instagram.png" alt="" aria-hidden="true" />
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
 
-  <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="/menu.js?v=113" defer></script>
   <script src="/components/footer-links.js?v=114" defer></script>
@@ -722,5 +722,12 @@
     defer
   ></script>
   <script src="/assets/consent.js" defer></script>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/index_live.html
+++ b/index_live.html
@@ -230,7 +230,65 @@ img, svg, video, iframe { max-width: 100%; height: auto; }
           });
         })
         .catch(() => {
-          target.innerHTML = '<footer class="site-footer"><div class="site-footer__inner container"><div class="site-footer__brand"><img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" /><p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p></div><div class="site-footer__top"><div data-footer-links-services></div><div data-footer-links-info></div><div data-footer-links-brand></div><div class="site-footer__contact"><h3 class="site-footer__title">Kontakt</h3><div class="site-footer__contact-lines"><div>My Strongest Side AS</div><div>Brages veg 3<br>5221 Nesttun</div><div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div></div></div></div><div class="site-footer__bottom"><div class="site-footer__social"><span class="site-footer__social-label">Følg oss i sosiale medier</span><div class="site-footer__social-list"><a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><img src="/icons/facebook.png" alt="" aria-hidden="true"></a><a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><img src="/icons/instagram.png" alt="" aria-hidden="true"></a><a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><img src="/icons/linkedin.png" alt="" aria-hidden="true"></a></div></div><p class="site-footer__meta">© <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053</p></div></div></footer>';
+          target.innerHTML = '<footer class="site-footer">
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
+
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
+
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>';
         });
     })();
   </script>
@@ -260,5 +318,14 @@ img, svg, video, iframe { max-width: 100%; height: auto; }
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/kontakt.html
+++ b/kontakt.html
@@ -479,46 +479,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="menu.js" defer></script>
   <script src="/components/footer-links.js?v=114" defer></script>
@@ -548,5 +566,13 @@
   </script>
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/kurs og seminar.html
+++ b/kurs og seminar.html
@@ -141,46 +141,64 @@
 
   <!-- FOOTER -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- External JS -->
   <script src="menu.js" defer></script>
@@ -248,5 +266,13 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -413,49 +413,64 @@ header[data-component="site-header"]{
 </main>
   <!-- FOOTER (samme struktur som du bruker) -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-              <img src="/icons/linkedin.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- External JS (ONE source) -->
   <script src="components/footer-links.js" defer></script>
@@ -512,5 +527,14 @@ header[data-component="site-header"]{
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/maintenance.html
+++ b/maintenance.html
@@ -158,5 +158,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/om-oss.html
+++ b/om-oss.html
@@ -275,46 +275,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer><script src="menu.js" defer></script>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p><script src="menu.js" defer></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -346,5 +364,13 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -2,7 +2,11 @@
 <footer class="site-footer">
   <div class="site-footer__inner container">
     <div class="site-footer__brand">
-      <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
       <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
     </div>
 
@@ -15,7 +19,7 @@
         <h3 class="site-footer__title">Kontakt</h3>
         <div class="site-footer__contact-lines">
           <div>My Strongest Side AS</div>
-          <div>Brages veg 3<br>5221 Nesttun</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
           <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
       </div>
@@ -25,14 +29,23 @@
       <div class="site-footer__social">
         <span class="site-footer__social-label">Følg oss i sosiale medier</span>
         <div class="site-footer__social-list">
-          <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-            <img src="/icons/facebook.png" alt="" aria-hidden="true">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
           </a>
-          <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-            <img src="/icons/instagram.png" alt="" aria-hidden="true">
-          </a>
-          <a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-            <img src="/icons/linkedin.png" alt="" aria-hidden="true">
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
           </a>
         </div>
       </div>
@@ -43,3 +56,5 @@
     </div>
   </div>
 </footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>

--- a/personvern.html
+++ b/personvern.html
@@ -64,47 +64,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-   
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="components/footer-links.js" defer></script>
   <script src="menu.js" defer></script>
@@ -116,5 +133,14 @@
 </style>
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/presse.html
+++ b/presse.html
@@ -132,47 +132,64 @@
 
   <!-- FOOTER -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- External JS (ONE source) --><script src="menu.js" defer></script>
   <script src="/components/footer-links.js?v=114" defer></script>
@@ -184,5 +201,13 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -43,5 +43,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/qr/trening/index.html
+++ b/qr/trening/index.html
@@ -364,49 +364,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-              <img src="/icons/linkedin.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="../../components/footer-links.js" defer></script>
   <script>
@@ -429,5 +444,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/samarbeid.html
+++ b/samarbeid.html
@@ -116,46 +116,64 @@
 
   <!-- FOOTER -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- External JS (ONE source) --><script src="menu.js" defer></script>
   <script src="/components/footer-links.js?v=114" defer></script>
@@ -167,5 +185,13 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningssystem.html
+++ b/treningssystem.html
@@ -222,47 +222,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer><script src="menu.js" defer></script>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p><script src="menu.js" defer></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -294,5 +311,13 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud.html
+++ b/treningstilbud.html
@@ -169,7 +169,65 @@
         })
         .catch(function(){
           // Minimal fallback hvis fetch feiler
-          target.innerHTML = '<footer class="site-footer"><div class="site-footer__inner container"><div class="site-footer__brand"><img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" /><p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p></div><div class="site-footer__top"><div data-footer-links-services></div><div data-footer-links-info></div><div data-footer-links-brand></div><div class="site-footer__contact"><h3 class="site-footer__title">Kontakt</h3><div class="site-footer__contact-lines"><div>My Strongest Side AS</div><div>Brages veg 3<br>5221 Nesttun</div><div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div></div></div></div><div class="site-footer__bottom"><div class="site-footer__social"><span class="site-footer__social-label">Følg oss i sosiale medier</span><div class="site-footer__social-list"><a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><img src="/icons/facebook.png" alt="" aria-hidden="true"></a><a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><img src="/icons/instagram.png" alt="" aria-hidden="true"></a><a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><img src="/icons/linkedin.png" alt="" aria-hidden="true"></a></div></div><p class="site-footer__meta">© <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053</p></div></div></footer>';
+          target.innerHTML = '<footer class="site-footer">
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
+
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
+
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>';
         });
     })();
   </script>
@@ -177,5 +235,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/barn-ungdom.html
+++ b/treningstilbud/barn-ungdom.html
@@ -462,46 +462,64 @@
 
   <!-- ===== FOOTER (som du hadde) ===== -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- Meny (beholder den som fungerer) --><script src="../menu.js" defer></script>
 
@@ -552,5 +570,13 @@
 </script>
 
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/lett-påmelding.html
+++ b/treningstilbud/lett-påmelding.html
@@ -652,46 +652,64 @@
   </div>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script>
     (function(){
@@ -784,5 +802,13 @@
   </script>
 
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/test.html
+++ b/treningstilbud/test.html
@@ -285,49 +285,64 @@
 
   <!-- FOOTER -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
-              <img src="/icons/linkedin.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <!-- Sticky bar (mobil) -->
   <div class="sticky-signup-bar" aria-label="Påmelding og pris">
@@ -361,5 +376,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/testpaa.html
+++ b/treningstilbud/testpaa.html
@@ -440,7 +440,65 @@
       })
       .catch(function(){
         // Minimal fallback hvis fetch feiler
-        target.innerHTML = '<footer class="site-footer"><div class="site-footer__inner container"><div class="site-footer__brand"><img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" /><p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p></div><div class="site-footer__top"><div data-footer-links-services></div><div data-footer-links-info></div><div data-footer-links-brand></div><div class="site-footer__contact"><h3 class="site-footer__title">Kontakt</h3><div class="site-footer__contact-lines"><div>My Strongest Side AS</div><div>Brages veg 3<br>5221 Nesttun</div><div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div></div></div></div><div class="site-footer__bottom"><div class="site-footer__social"><span class="site-footer__social-label">Følg oss i sosiale medier</span><div class="site-footer__social-list"><a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook"><img src="/icons/facebook.png" alt="" aria-hidden="true"></a><a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"><img src="/icons/instagram.png" alt="" aria-hidden="true"></a><a class="social-link" href="https://www.linkedin.com/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"><img src="/icons/linkedin.png" alt="" aria-hidden="true"></a></div></div><p class="site-footer__meta">© <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053</p></div></div></footer>';
+        target.innerHTML = '<footer class="site-footer">
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
+
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
+
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>';
       });
   })();
 </script>
@@ -448,5 +506,14 @@
 
   <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/tett-oppfolging.html
+++ b/treningstilbud/tett-oppfolging.html
@@ -411,46 +411,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="../components/footer-links.js" defer></script>
   <script src="../menu.js" defer></script>
@@ -500,5 +518,14 @@
 </script>
 
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/tett-påmelding.html
+++ b/treningstilbud/tett-påmelding.html
@@ -647,46 +647,64 @@
   </div>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script>
     (function(){
@@ -778,5 +796,13 @@
     })();
   </script>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/ungdom-paamelding.html
+++ b/treningstilbud/ungdom-paamelding.html
@@ -679,46 +679,64 @@
 
   <!-- ===== FOOTER (samme som infosiden) ===== -->
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script>
     (function(){
@@ -809,5 +827,13 @@
 </script>
 
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/treningstilbud/voksne-lett.html
+++ b/treningstilbud/voksne-lett.html
@@ -439,46 +439,64 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner container">
-      <div class="site-footer__brand">
-        <img src="/bilder/myss-logo-footer.png" alt="My Strongest Side" class="site-footer__logo" />
-        <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
-      </div>
+  <div class="site-footer__inner container">
+    <div class="site-footer__brand">
+      <img
+        src="/bilder/myss-logo-footer.png"
+        alt="My Strongest Side"
+        class="site-footer__logo"
+      />
+      <p class="site-footer__tagline">Gjør trening tilgjengelig for flest mulig</p>
+    </div>
 
-      <div class="site-footer__top">
-        <div data-footer-links-services></div>
-        <div data-footer-links-info></div>
-        <div data-footer-links-brand></div>
+    <div class="site-footer__top">
+      <div data-footer-links-services></div>
+      <div data-footer-links-info></div>
+      <div data-footer-links-brand></div>
 
-        <div class="site-footer__contact">
-          <h3 class="site-footer__title">Kontakt</h3>
-          <div class="site-footer__contact-lines">
-            <div>My Strongest Side AS</div>
-            <div>Brages veg 3<br>5221 Nesttun</div>
-            <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
-          </div>
+      <div class="site-footer__contact">
+        <h3 class="site-footer__title">Kontakt</h3>
+        <div class="site-footer__contact-lines">
+          <div>My Strongest Side AS</div>
+          <div>Brages veg 3<br />5221 Nesttun</div>
+          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
         </div>
-      </div>
-
-      <div class="site-footer__bottom">
-        <div class="site-footer__social">
-          <span class="site-footer__social-label">Følg oss i sosiale medier</span>
-          <div class="site-footer__social-list">
-            <a class="social-link" href="https://www.facebook.com/" target="_blank" rel="noopener noreferrer" aria-label="Facebook">
-              <img src="/icons/facebook.png" alt="" aria-hidden="true">
-            </a>
-            <a class="social-link" href="https://www.instagram.com/mystrongestside/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
-              <img src="/icons/instagram.png" alt="" aria-hidden="true">
-            </a>
-          </div>
-        </div>
-
-        <p class="site-footer__meta">
-          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-        </p>
       </div>
     </div>
-  </footer>
+
+    <div class="site-footer__bottom">
+      <div class="site-footer__social">
+        <span class="site-footer__social-label">Følg oss i sosiale medier</span>
+        <div class="site-footer__social-list">
+          <a
+            class="social-link"
+            href="https://www.facebook.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Facebook"
+          >
+            <img src="/icons/facebook.png" alt="" aria-hidden="true" />
+          </a>
+          <a
+            class="social-link"
+            href="https://www.instagram.com/mystrongestside/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Instagram"
+          >
+            <img src="/icons/instagram.png" alt="" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+
+      <p class="site-footer__meta">
+        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+      </p>
+    </div>
+  </div>
+</footer>
+
+<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
 
   <script src="../menu.js" defer></script>
 
@@ -533,5 +551,13 @@
   </script>
 
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>

--- a/veiledere/beinpress-grep.html
+++ b/veiledere/beinpress-grep.html
@@ -120,5 +120,14 @@
     </section>
   </main>
   <script src="/assets/consent.js" defer></script>
+
+<script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var y = document.getElementById("year");
+    if (y) y.textContent = new Date().getFullYear();
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Samle og standardisere footer-markup på alle sider slik at alle bruker nøyaktig samme struktur som på forsiden, inkludert merkelappen for varemerket og automatisk årstallsoppdatering.
- Sikre at nødvendige klient-skript for meny og dynamiske footer-lenker lastes på sluttet av dokumentene for konsistent oppførsel på alle sider.

### Description
- Erstattet alle forekomster av `<footer class="site-footer">...</footer>` med den eksakte leverte footer-strukturen og la til `<p class="myss-legal">...` der det manglet, samt oppdaterte `partials/footer.html` med canonical-markup. 
- La til eller oppdaterte skriptaggene før `</body>` i alle sider til å inneholde ` <script src="/menu.js?v=113" defer></script>`, `<script src="/components/footer-links.js?v=114" defer></script>` og årstall-scriptet som oppdaterer `#year` ved `DOMContentLoaded`.
- Beholdt eksisterende sideinnhold uendret utover footer- og script-innsettingene og la inn samme fallback-HTML i klient-side fetch-funksjoner der `partials/footer.html` brukes.
- Endringer ble brukt på et sett HTML-filer (se liste over oppdaterte filer i commit-endringen). Files som manglet `footer-links.js` før oppdatering: `aktuelt/cp-bladet-myss.html`, `gruppetrening.html`, `index_live.html`, `main.html`, `partials/footer.html`, `personvern.html`, `qr/trening/index.html`, `treningstilbud.html`, `treningstilbud/test.html`, `treningstilbud/testpaa.html`, `treningstilbud/tett-oppfolging.html`. Files som hadde avvikende footer før oppdatering: `aktuelt/cp-bladet-myss.html`, `gruppetrening.html`, `index.html`, `index_live.html`, `kontakt.html`, `kurs og seminar.html`, `main.html`, `om-oss.html`, `partials/footer.html`, `personvern.html`, `presse.html`, `qr/trening/index.html`, `samarbeid.html`, `treningssystem.html`, `treningstilbud.html`, `treningstilbud/barn-ungdom.html`, `treningstilbud/test.html`, `treningstilbud/testpaa.html`, `treningstilbud/tett-oppfolging.html`, `treningstilbud/ungdom-paamelding.html`, `treningstilbud/voksne-lett.html`.

### Testing
- Kjørte automatiske sjekker (Python-skript) som listet HTML-filer, validerte at alle sider med `</body>` inneholder `menu.js`, `footer-links.js` og årstall-scriptet, og resultatet viste ingen sider manglet disse script-tagene etter endringene (`missing count 0`).
- Kjørte en kontroll som bekreftet at ingen `site-footer`-blokker avviker fra den eksakte målstrukturen etter endringene (`nonexact 0`).
- Serverte innholdet lokalt og tok et full-page screenshot av `index.html` via Playwright for visuell verifisering, og endringene ble committet (endret filer reflektert i commit i repo).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac13d5c53c833097ba71aa77d22d26)