### PR TITLE
Rydd opp footer og script-seksjon i kontakt.html

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -499,7 +499,11 @@
         <div class="site-footer__contact-lines">
           <div>My Strongest Side AS</div>
           <div>Brages veg 3<br />5221 Nesttun</div>
-          <div><a class="site-footer__link" href="/kontakt.html">Meld interesse eller still spørsmål</a></div>
+          <div>
+            <a class="site-footer__link" href="/kontakt.html">
+              Meld interesse eller still spørsmål
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -529,47 +533,41 @@
         </div>
       </div>
 
-      <p class="site-footer__meta">
-        © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
-      </p>
+      <div class="site-footer__meta-wrap">
+        <p class="site-footer__meta">
+          © <span id="year"></span> My Strongest Side AS · Org.nr 935 786 053
+        </p>
+        <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
+      </div>
     </div>
   </div>
 </footer>
 
-<p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
-
-  <script src="menu.js" defer></script>
-  <script src="/components/footer-links.js?v=114" defer></script>
-  <script src="/assets/consent.js" defer></script>
-  <script src="/assets/js/contact-form.js" defer></script>
-
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      const buttons = document.querySelectorAll('[data-message-template]');
-      const messageField = document.getElementById('message');
-
-      buttons.forEach(function (button) {
-        button.addEventListener('click', function () {
-          const text = button.getAttribute('data-message-template') || '';
-          if (!messageField) return;
-
-          if (messageField.value.trim() === '') {
-            messageField.value = text + ' ';
-          } else {
-            messageField.value = text + '\n\n' + messageField.value.trim();
-          }
-
-          messageField.focus();
-        });
-      });
-    });
-  </script>
-
-  <p class="myss-legal">My Strongest Side® er et registrert varemerke.</p>
-
 <script src="/menu.js?v=113" defer></script>
+<script src="/components/footer-links.js?v=114" defer></script>
+<script src="/assets/consent.js" defer></script>
+<script src="/assets/js/contact-form.js" defer></script>
+
 <script>
   document.addEventListener("DOMContentLoaded", function () {
+    const buttons = document.querySelectorAll("[data-message-template]");
+    const messageField = document.getElementById("message");
+
+    buttons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        const text = button.getAttribute("data-message-template") || "";
+        if (!messageField) return;
+
+        if (messageField.value.trim() === "") {
+          messageField.value = text + " ";
+        } else {
+          messageField.value = text + "\n\n" + messageField.value.trim();
+        }
+
+        messageField.focus();
+      });
+    });
+
     var y = document.getElementById("year");
     if (y) y.textContent = new Date().getFullYear();
   });


### PR DESCRIPTION
### Motivation
- Fjerne duplikater og rydde opp bunnen av `kontakt.html` slik at footer, varemerkmelding og script-innlastinger er konsistente og i korrekt rekkefølge.
- Samle DOM-ready logikk i én inline scriptblokk for enklere vedlikehold og for å sikre at både meldingsknapper og årstallet håndteres sammen.

### Description
- Erstattet hele delen fra `<footer class="site-footer">` til filslutt med den ryddede versjonen som inneholder kun én `footer` og ett eksemplar av `<p class="myss-legal">` plassert i `site-footer__meta-wrap` under `site-footer__meta`.
- Fjernet duplisert `menu.js` og beholdt kun `<script src="/menu.js?v=113" defer></script>`, samtidig som `footer-links.js`, `consent.js` og `contact-form.js` ble beholdt.
- Slått sammen `year`-skriptet inn i eksisterende `DOMContentLoaded`-handler slik at både knapp-innsetting i meldingsfelt og oppdatering av `#year` skjer i samme inline scriptblokk.
- Sikret avslutningsrekkefølgen: `footer` → scripts → ett samlet inline script → `</body>` → `</html>`.

### Testing
- Kjørte `rg -n "myss-legal|menu.js|DOMContentLoaded|site-footer__meta-wrap" kontakt.html` for å verifisere referanser og funn, og resultatene stemte med endringene (suksess).
- Inspeksjon av filslutt med `tail -n` bekreftet at footer- og script-seksjonen er som forventet (suksess).
- `git commit` kjørt for endringen og registrert som en endring i repo (suksess).
- Forsøk på å ta en headless-screenshot via Playwright ble forsøkt, men feilet i miljøet på grunn av Chromium-prosessens `SIGSEGV` (automatisert test forsøkt, men mislyktes på grunn av miljøfeil).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac19885eac8330968eea94ac17e6f1)