### PR TITLE
Stram inn typografi for .site-footer i styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3249,3 +3249,74 @@ html.nav-open .site-header {
 #instagram .ig-fallback { margin: 0 0 12px; opacity: .9; }
 #instagram .ig-fallback a { font-weight: 800; }
 #instagram .sk-instagram-feed { min-height: 180px; }
+
+/* Footer typography tightening */
+.site-footer {
+  background: #0c2d48;
+  color: #ffffff;
+}
+
+.site-footer,
+.site-footer * {
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.site-footer__title {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  line-height: 1.3;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.site-footer__tagline,
+.site-footer__contact-lines,
+.site-footer__link,
+.site-footer__social-label,
+.site-footer__meta,
+.myss-legal {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  font-weight: 400;
+}
+
+.site-footer__tagline,
+.site-footer__meta,
+.myss-legal,
+.site-footer__social-label {
+  margin: 0;
+}
+
+.site-footer__contact-lines > div + div {
+  margin-top: 8px;
+}
+
+.site-footer__link {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.site-footer__link:hover,
+.site-footer__link:focus-visible {
+  text-decoration: underline;
+}
+
+.site-footer__bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.site-footer__meta-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.myss-legal {
+  opacity: 0.82;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
### Motivation
- Standardisere og stramme inn typografi og spacing i footer for bedre lesbarhet og konsekvent utseende på tvers av sidene.

### Description
- La til en samlet CSS-blokk i `styles.css` som definerer `.site-footer` bakgrunn og tekstfarge, samt arvet `font-family` og `box-sizing` for alle under-elementer.
- Implementerte typografiregler for `.site-footer__title`, `.site-footer__tagline`, `.site-footer__contact-lines`, `.site-footer__link`, `.site-footer__social-label`, `.site-footer__meta` og `.myss-legal`, inkludert link-hover/focus, spacing for kontaktlinjer, `.site-footer__bottom` flex-layout og `.site-footer__meta-wrap`.

### Testing
- Kjørte `git diff --check` uten funn av problemer.
- Kjørte et automatisk Playwright-skript som lastet `http://127.0.0.1:8000/treningstilbud/test.html` og tok et skjermbilde av footeren (suksess).
- Brukte `rg` for å verifisere at de relevante footer-selektorene finnes i HTML/CSS-koden etter endringen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac199b63b4833091ce0286e264ee49)