### PR TITLE
Stram opp språk i kontaktskjema-seksjonen

### DIFF
--- a/kontakt.html
+++ b/kontakt.html
@@ -375,29 +375,29 @@
         <p class="contact-eyebrow">Kontakt</p>
         <h1>Kontakt oss om trening, tilrettelegging eller samarbeid</h1>
         <p class="contact-lead">
-          Vi svarer deltakere, pårørende, fagpersoner og samarbeidspartnere som ønsker konkret informasjon om tilbud,
-          oppfølging eller neste steg.
+          Vi svarer deltakere, pårørende, fagpersoner og samarbeidspartnere som ønsker informasjon om tilbud,
+          tilrettelegging eller samarbeid.
         </p>
       </div>
     </section>
 
     <section class="container contact-section" aria-labelledby="contact-intro-heading">
       <div class="contact-intro">
-        <h2 id="contact-intro-heading">Hvem siden er for – og hva du kan ta kontakt om</h2>
+        <h2 id="contact-intro-heading">Hvem siden er for og hva du kan kontakte oss om</h2>
         <p>
-          Denne siden er laget for deg som vurderer tilbud hos My Strongest Side, følger opp en deltaker,
-          representerer et fagmiljø eller ønsker samarbeid. Bruk skjemaet under, så følger vi opp raskt og ryddig.
+          Denne siden er for deg som vurderer et tilbud hos My Strongest Side, følger opp en deltaker,
+          representerer et fagmiljø eller ønsker samarbeid. Bruk skjemaet under for å sende oss en henvendelse.
         </p>
       </div>
 
       <div class="contact-layout">
         <article class="contact-form-wrap" aria-labelledby="contact-form-heading">
-          <h3 id="contact-form-heading">Send oss en melding</h3>
+          <h3 id="contact-form-heading">Meld interesse eller still spørsmål</h3>
           <p class="contact-help-text">
-            Du kan bruke skjemaet for å melde interesse for gruppetrening, spørre om tilrettelegging eller ta kontakt om samarbeid.
+            Bruk skjemaet for å melde interesse for gruppetrening, stille spørsmål om tilrettelegging eller ta kontakt om samarbeid.
           </p>
 
-          <p class="contact-next-step">Velg hva henvendelsen gjelder, så fyller vi inn forslag i meldingsfeltet.</p>
+          <p class="contact-next-step">Velg hva henvendelsen gjelder. Da fylles det inn et forslag i meldingsfeltet.</p>
           <div class="contact-quick-links" aria-label="Hurtigvalg for meldingstype">
             <button type="button" data-message-template="Jeg ønsker å melde interesse for ungdomsgruppen." aria-label="Meld interesse for ungdomsgruppen">Meld interesse for ungdomsgruppen</button>
             <button type="button" data-message-template="Jeg ønsker å melde interesse for gruppetrening fra 16 år." aria-label="Meld interesse for gruppetrening fra 16 år">Meld interesse fra 16 år</button>
@@ -406,7 +406,7 @@
           </div>
 
           <p class="contact-reassurance" aria-label="Trygghet ved kontakt">
-            Det er lav terskel for å ta kontakt. Du trenger ikke vite nøyaktig hva du skal skrive – vi hjelper deg videre steg for steg.
+            Du trenger ikke formulere alt perfekt. Send oss en kort melding, så følger vi opp henvendelsen.
           </p>
 
           <form id="contactForm" name="contact" method="POST" data-netlify="true" netlify-honeypot="company" data-js="contact-form">
@@ -434,7 +434,7 @@
             </div>
 
             <div class="form-group">
-              <label for="message">Hva ønsker du hjelp med?</label>
+              <label for="message">Hva gjelder henvendelsen?</label>
               <textarea id="message" name="message" rows="6" required minlength="10" maxlength="2000" placeholder="Skriv gjerne kort hva det gjelder, så følger vi deg opp videre."></textarea>
             </div>
 
@@ -442,7 +442,7 @@
             <div class="form-feedback" hidden data-js="form-feedback" aria-live="polite" role="status"></div>
 
             <p class="form-privacy-note">
-              Ved innsending lagrer vi kontaktinformasjonen din for å kunne svare på henvendelsen.
+              Når du sender inn skjemaet, lagrer vi kontaktinformasjonen din for å kunne svare på henvendelsen.
               Opplysningene slettes normalt innen 12 måneder. Les mer i
               <a href="/personvern.html">personvernerklæringen</a>.
             </p>
@@ -460,7 +460,7 @@
           </section>
 
           <section aria-labelledby="contact-topics-heading">
-            <h4 id="contact-topics-heading">Dette kan du ta kontakt om</h4>
+            <h4 id="contact-topics-heading">Dette kan du kontakte oss om</h4>
             <ul>
               <li>Gruppetrening for ungdom og voksne</li>
               <li>Tilrettelegging ved syns- eller bevegelsesutfordringer</li>
@@ -470,8 +470,8 @@
 
           <section aria-labelledby="contact-follow-up-heading">
             <h4 id="contact-follow-up-heading">Trygg oppfølging</h4>
-            <p>Hos oss er det lav terskel for å ta kontakt, enten du er deltaker, pårørende eller fagperson.</p>
-            <p>Vi følger opp henvendelser så raskt vi kan, og hjelper deg med neste steg.</p>
+            <p>Du kan kontakte oss enten du er deltaker, pårørende eller fagperson.</p>
+            <p>Vi svarer så raskt vi kan og følger opp henvendelsen på en ryddig måte.</p>
           </section>
         </aside>
       </div>


### PR DESCRIPTION
### Motivation
- Gjøre teksten i kontaktskjema-delen tydeligere, mer norsk og mer profesjonell, og fjerne generiske/amerikanske formuleringer.
- Beholde eksisterende funksjonalitet, knappetekst og kontaktinformasjon uendret for å unngå regress.
- Ønske om konsistent tone med resten av My Strongest Side ved å bruke kortfattede, bokmålske formuleringer.

### Description
- Oppdatert ingress under hovedoverskriften til: `Vi svarer deltakere, pårørende, fagpersoner og samarbeidspartnere som ønsker informasjon om tilbud, tilrettelegging eller samarbeid.`
- Endret intro-seksjonens overskrift til `Hvem siden er for og hva du kan kontakte oss om` og avsnittet under til å invitere til å sende en henvendelse.
- Endret skjemaoverskrift, hjelpetekster, hurtigtekst, forsikringstekst, feltetikett fra `Hva ønsker du hjelp med?` til `Hva gjelder henvendelsen?`, og personverntekst til ønsket formulering.
- Endret kolonneoverskrift `Dette kan du ta kontakt om` til `Dette kan du kontakte oss om` og oppdatert avsnittet under `Trygg oppfølging` til en mer direkte formulering.

### Testing
- Søkt og verifisert endrede tekststrenger med `rg` mot `kontakt.html` og funnet alle forventede endringer, som lykkes uten treff på uønskede formuleringer.
- Startet lokal HTTP-server med `python3 -m http.server 4173` og lastet siden for visuell verifikasjon, som viste oppdateringene.
- Generert en helside-skjermdump via Playwright for visuell kontroll av endringene, som ble tatt uten feil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1ab285008330a5d48193d189cba3)