### PR TITLE
Forbedre tydelighet i teamseksjonen på Individuelloppfølging

### DIFF
--- a/Individuelloppfølging.html
+++ b/Individuelloppfølging.html
@@ -169,14 +169,14 @@
         <h2 class="reveal d2">Teamet</h2>
         <p class="reveal d3">
           My Strongest Side kombinerer prestasjonserfaring og helsefaglig kompetanse.
-          Målet er alltid det samme: trygg, forståelig og inkluderende trening – tilpasset deg.
+          Her kan du lese mer om Alexander Sviggum og Amir Asadollahzadeh, og hvordan vi jobber med trygg, forståelig og inkluderende trening.
         </p>
 
         <div class="partner-list mt-md">
 
           <!-- Alexander -->
           <article class="mt-md partner-card">
-            <h3 class="mt-sm reveal d2">Hvem er Alexander</h3>
+            <h3 class="mt-sm reveal d2">Alexander Sviggum</h3>
            <p class="reveal d3">
 <strong>Alexander Sviggum</strong> er <strong>daglig leder og eier</strong> av My Strongest Side AS, og <strong>ergoterapeut</strong>
               med kompetanse innen <strong>aktivitet, funksjon, tilrettelegging og deltakelse</strong>. Han har cerebral parese og lang egen erfaring
@@ -202,7 +202,7 @@
 
           <!-- Amir -->
           <article class="mt-lg partner-card">
-            <h3 class="mt-sm reveal d2">Hvem er Amir</h3>
+            <h3 class="mt-sm reveal d2">Amir Asadollahzadeh</h3>
 
             <p class="reveal d3">
               <strong>Amir Asadollahzadeh</strong> er hovedtrener i My Strongest Side, med bachelorgrad i kroppsøving og solid kompetanse innen treningsplanlegging,


### PR DESCRIPTION
### Motivation
- Gjøre team-seksjonen mer profesjonell og tydelig ved å bruke fulle navn og en kort, presis introduksjon som forklarer kompetanse og arbeidsmåte. 
- Beholde eksisterende layout, klasser og struktur slik at visuell utforming og styling ikke endres.

### Description
- Oppdatert introteksten i team-delen til: `Her kan du lese mer om Alexander Sviggum og Amir Asadollahzadeh, og hvordan vi jobber med trygg, forståelig og inkluderende trening.`
- Endret overskriften `Hvem er Alexander` til `Alexander Sviggum` i `Individuelloppfølging.html`.
- Endret overskriften `Hvem er Amir` til `Amir Asadollahzadeh` i `Individuelloppfølging.html`.
- Beholdt all eksisterende klassebruk, HTML-struktur og brødtekst for å unngå å påvirke styling eller layout; endringen er liten (3 innsettinger / 3 slettinger).

### Testing
- Kjørte `rg -n` for å verifisere at de nye tekststrengene finnes i `Individuelloppfølging.html`, og søket returnerte de forventede treffene (suksess).
- Inspiserte relevante linjer med `sed`/`nl -ba` for å bekrefte korrekt innsetting og at HTML er gyldig (suksess).
- Kjørte `git commit` for å lagre endringen i repoet, og committen ble opprettet uten feil (suksess).
- Forsøkte å generere et visuelt screenshot med Playwright for å verifisere render, men Chromium krasjet i miljøet (SIGSEGV), så skjermbildeverifisering feilet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1c7e034c83309ac4c1e130a5e162)